### PR TITLE
Generic vecs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,8 @@
 [package]
-name = "compressed_dst"
+name = "packed_vec"
 version = "0.1.0"
 authors = ["Gabriela Alexandra Moldovan <gabi_250@live.com>"]
+
+[dependencies]
+num = "0.1.40"
+rand = "0.3"

--- a/README.md
+++ b/README.md
@@ -1,20 +1,20 @@
-# Smaller immutable `Vec<u64>`s
+# Smaller immutable `Vec<u*>`s
 This library provides a more efficient way of storing immutable
-lists of `u64` values.
+lists of unsigned integer values.
 
 A `PackedVec` is a `struct` that stores the elements of a given `Vec<u64>` as
 a series of`N` bit values, where `N` is the number of bits needed to represent
 the largest number from the original list.
 
 The `struct` stores the elements of the original `vec` as a smaller collection
-of `u64` values. This is achieved by storing multiple elements inside a single
-`u64` value.
+of `u*` values. This is achieved by storing multiple elements inside a single
+`u*` value.
 
 ```
-    use compressed_dst::small_vec::PackedVec;
+    use packed_vec:::PackedVec;
 
     let v = vec![1, 4294967296, 2, 3, 4294967296, 5];
-    let mut small_vec = PackedVec::from_u64_vec(v);
+    let mut small_vec = PackedVec::new(v);
     assert_eq!(small_vec.get(1), 4294967296);
     assert_eq!(small_vec.iter().next(), Some(1));
 ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,20 +1,39 @@
-const WORD_SIZE:usize = 64;
+extern crate num;
+extern crate rand;
+
+use num::{Unsigned, ToPrimitive};
+use num::cast::{FromPrimitive};
+use std::cmp::Ord;
+use std::marker::PhantomData;
+
+const WORD_SIZE: usize = 64;
+
+fn i_log2(number: u64) -> usize {
+    let mut bits = 63;
+    while number & (1 << bits) == 0 {
+        bits -= 1;
+    }
+    bits + 1
+}
 
 #[derive(Debug)]
-pub struct PackedVec {
+pub struct PackedVec<T> {
     len: usize,
     bits: Vec<u64>,
     item_width: usize,
+    phantom: PhantomData<T>,
 }
 
 #[derive(Debug)]
-pub struct PackedVecIter<'a> {
-    packed_vec: &'a PackedVec,
+pub struct PackedVecIter<'a, T> where
+    T: 'a + Unsigned + ToPrimitive + Ord + FromPrimitive {
+    packed_vec: &'a PackedVec<T>,
     idx: usize,
 }
 
-impl<'a> Iterator for PackedVecIter<'a> {
-    type Item = u64;
+impl<'a, T> Iterator for PackedVecIter<'a, T> where
+    T: 'a + Unsigned + ToPrimitive + FromPrimitive + Ord {
+    type Item = T;
 
     fn next(&mut self) -> Option<Self::Item> {
         self.idx += 1;
@@ -22,16 +41,18 @@ impl<'a> Iterator for PackedVecIter<'a> {
     }
 }
 
-impl <'a> PackedVec {
+impl <'a, T> PackedVec<T> where
+    T: Unsigned + ToPrimitive + FromPrimitive + Ord {
     /// Return the value at the specified `index`
     /// # Example
     /// ```
-    /// use compressed_dst::PackedVec;
-    /// let v = vec![1, 2, 3, 4];
-    /// let small_vec = PackedVec::from_u64_vec(v);
-    /// assert_eq!(small_vec.get(3), Some(4));
+    /// use packed_vec::PackedVec;
+    /// let v: Vec<u8> = vec![1, 2, 3, 4];
+    /// let packed_vec = PackedVec::new(v);
+    /// let val: Option<u8> = packed_vec.get(3);
+    /// assert_eq!(val, Some(4));
     /// ```
-    pub fn get(&self, index: usize) -> Option<u64> {
+    pub fn get(&self, index: usize) -> Option<T> {
         if index >= self.len {
             return None;
         }
@@ -40,53 +61,52 @@ impl <'a> PackedVec {
         if start + self.item_width < WORD_SIZE {
             let mask = ((1 << self.item_width) - 1)
                 << (WORD_SIZE - self.item_width - start);
-            let item = (self.bits[item_index] & mask) >>
+            let item = (self.bits[item_index].to_u64().unwrap() & mask) >>
                 (WORD_SIZE - self.item_width - start);
-            Some(item)
+            Some(FromPrimitive::from_u64(item).unwrap())
         } else if self.item_width == WORD_SIZE {
-            Some(self.bits[item_index])
+            Some(FromPrimitive::from_u64(self.bits[item_index].to_u64()
+                    .unwrap()).unwrap())
         } else {
             let bits_written = WORD_SIZE - start;
             let mask = ((1 << bits_written) - 1)
                 << (WORD_SIZE - bits_written - start);
-            let first_half = (self.bits[item_index] & mask)
+            let first_half = (self.bits[item_index].to_u64().unwrap() & mask)
                 >> (WORD_SIZE - bits_written - start);
             // second half
             let remaining_bits = self.item_width - bits_written;
             if remaining_bits > 0 {
                 let mask = ((1 << remaining_bits) - 1)
                     << (WORD_SIZE - remaining_bits);
-                let second_half = (self.bits[item_index + 1] & mask)
+                let second_half = (self.bits[item_index + 1].to_u64().unwrap() & mask)
                     >> (WORD_SIZE - remaining_bits);
-                Some((first_half << remaining_bits) + second_half)
+                Some(FromPrimitive::from_u64(
+                        (first_half << remaining_bits) + second_half).unwrap())
             } else {
-                Some(first_half)
+                Some(FromPrimitive::from_u64(first_half).unwrap())
             }
         }
     }
 
     /// Return a `PackedVec` containing a compressed version of the elements of
     /// `vec`.
-    pub fn from_u64_vec(vec: Vec<u64>) -> PackedVec {
+    pub fn new(vec: Vec<T>) -> PackedVec<T> {
         let len = vec.len();
         let item_width = if let Some(v) = vec.iter().max() {
-            let log = (*v as f64).log2();
-            if log == log.ceil() {
-                (log + 1.0) as usize
-            } else {
-                log.ceil() as usize
-            }
+            i_log2((*v).to_u64().unwrap())
         } else {
             return PackedVec {
                 len: 0,
                 bits: vec![],
                 item_width: 0,
+                phantom: PhantomData,
             };
         };
         let mut bit_vec = vec![];
         let mut buf: u64 = 0;
         let mut bit_count: usize = 0;
-        for &item in vec.iter() {
+        for ref item in vec.iter() {
+            let item = item.to_u64().unwrap();
             if bit_count + item_width < WORD_SIZE {
                 let shifted_item = item << WORD_SIZE - (item_width + bit_count);
                 buf |= shifted_item;
@@ -120,23 +140,24 @@ impl <'a> PackedVec {
             len: len,
             bits: bit_vec,
             item_width: item_width,
+            phantom: PhantomData,
         }
     }
 
     /// Return the number of elements in this.
     /// # Example
     /// ```
-    /// use compressed_dst::PackedVec;
-    /// let v = vec![1, 2, 3, 4];
-    /// let small_vec = PackedVec::from_u64_vec(v);
-    /// assert_eq!(small_vec.len(), 4);
+    /// use packed_vec::PackedVec;
+    /// let v: Vec<u16> = vec![1, 2, 3, 4];
+    /// let packed_vec = PackedVec::new(v);
+    /// assert_eq!(packed_vec.len(), 4);
     /// ```
     pub fn len(&self) -> usize {
         self.len
     }
 
     /// An iterator over the elements of the vector.
-    pub fn iter(&'a self) -> PackedVecIter<'a> {
+    pub fn iter(&'a self) -> PackedVecIter<'a, T> {
         PackedVecIter {
             packed_vec: &self,
             idx: 0,
@@ -147,28 +168,29 @@ impl <'a> PackedVec {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rand;
 
     #[test]
     fn empty_vec() {
-        let v = vec![];
-        let small_v = PackedVec::from_u64_vec(v);
-        assert_eq!(small_v.len(), 0);
-        assert_eq!(small_v.item_width, 0);
-        assert_eq!(small_v.bits, vec![]);
-        let mut iter = small_v.iter();
+        let v: Vec<u16> = vec![];
+        let packed_v = PackedVec::new(v);
+        assert_eq!(packed_v.len(), 0);
+        assert_eq!(packed_v.item_width, 0);
+        assert_eq!(packed_v.bits, vec![]);
+        let mut iter = packed_v.iter();
         assert_eq!(iter.idx, 0);
         assert_eq!(iter.next(), None);
     }
 
     #[test]
     fn all_values_fit_in_one_item() {
-        let v = vec![1, 2, 3];
+        let v: Vec<u16> = vec![1, 2, 3];
         let v_len = v.len();
-        let small_v = PackedVec::from_u64_vec(v.clone());
-        assert_eq!(small_v.len(), v_len);
-        assert_eq!(small_v.item_width, 2);
-        assert_eq!(small_v.bits, vec![7782220156096217088]);
-        let mut iter = small_v.iter();
+        let packed_v = PackedVec::new(v.clone());
+        assert_eq!(packed_v.len(), v_len);
+        assert_eq!(packed_v.item_width, 2);
+        assert_eq!(packed_v.bits, vec![7782220156096217088]);
+        let mut iter = packed_v.iter();
         for number in v {
             assert_eq!(iter.next(), Some(number));
         }
@@ -177,15 +199,15 @@ mod tests {
 
     #[test]
     fn value_spanning_two_items() {
-        let v = vec![1, 4294967296, 2, 3, 4294967296, 5];
+        let v: Vec<u64> = vec![1, 4294967296, 2, 3, 4294967296, 5];
         let v_len = v.len();
-        let small_v = PackedVec::from_u64_vec(v.clone());
-        assert_eq!(small_v.len(), v_len);
-        assert_eq!(small_v.item_width, 33);
-        assert_eq!(small_v.bits, vec![3221225472, 1073741824,
+        let packed_v = PackedVec::new(v.clone());
+        assert_eq!(packed_v.len(), v_len);
+        assert_eq!(packed_v.item_width, 33);
+        assert_eq!(packed_v.bits, vec![3221225472, 1073741824,
                                       4035225266123964416,
                                       1441151880758558720]);
-        let mut iter = small_v.iter();
+        let mut iter = packed_v.iter();
         for number in v {
             assert_eq!(iter.next(), Some(number));
         }
@@ -194,16 +216,94 @@ mod tests {
 
     #[test]
     fn values_fill_item_width() {
-        let v = vec![1, 2, 9223372036854775808, 100, 0, 3];
+        let v: Vec<u64> = vec![1, 2, 9223372036854775808, 100, 0, 3];
         let v_len = v.len();
-        let small_v = PackedVec::from_u64_vec(v.clone());
-        assert_eq!(small_v.len(), v_len);
-        assert_eq!(small_v.item_width, 64);
-        assert_eq!(small_v.bits, v);
-        let mut iter = small_v.iter();
+        let packed_v = PackedVec::new(v.clone());
+        assert_eq!(packed_v.len(), v_len);
+        assert_eq!(packed_v.item_width, 64);
+        assert_eq!(packed_v.bits, v);
+        let mut iter = packed_v.iter();
         for number in v {
             assert_eq!(iter.next(), Some(number));
         }
         assert_eq!(iter.next(), None);
+    }
+
+    #[test]
+    fn vec_u8() {
+        let v: Vec<u8> = vec![255, 2, 255];
+        let v_len = v.len();
+        let packed_v = PackedVec::new(v.clone());
+        assert_eq!(packed_v.len(), v_len);
+        let mut iter = packed_v.iter();
+        for number in v {
+            let value: Option<u8> = iter.next();
+            assert_eq!(value, Some(number));
+        }
+        assert_eq!(iter.next(), None);
+    }
+
+    #[test]
+    fn vec_u16() {
+        let v: Vec<u16> = vec![1, 2, 65535];
+        let v_len = v.len();
+        let packed_v = PackedVec::new(v.clone());
+        assert_eq!(packed_v.len(), v_len);
+        let mut iter = packed_v.iter();
+        for number in v {
+            let value: Option<u16> = iter.next();
+            assert_eq!(value, Some(number));
+        }
+        assert_eq!(iter.next(), None);
+    }
+
+    #[test]
+    fn vec_u32() {
+        let v: Vec<u32> = vec![1, 4294967295, 2, 100, 65535];
+        let v_len = v.len();
+        let packed_v = PackedVec::new(v.clone());
+        assert_eq!(packed_v.len(), v_len);
+        let mut iter = packed_v.iter();
+        for number in v {
+            let value: Option<u32> = iter.next();
+            assert_eq!(value, Some(number));
+        }
+        assert_eq!(iter.next(), None);
+    }
+
+    #[test]
+    fn vec_u64() {
+        let v: Vec<u64> = vec![1, 4294967295, 18446744073709551615,
+                               100, 18446744073709551613, 65535];
+        let v_len = v.len();
+        let packed_v = PackedVec::new(v.clone());
+        assert_eq!(packed_v.len(), v_len);
+        let mut iter = packed_v.iter();
+        for number in v {
+            let value: Option<u64> = iter.next();
+            assert_eq!(value, Some(number));
+        }
+        assert_eq!(iter.next(), None);
+    }
+
+    fn random_unsigned_ints<T>()
+        where T: Unsigned + ToPrimitive + FromPrimitive + Ord + Clone
+            + std::fmt::Debug + rand::Rand {
+        const LENGTH: usize = 100000;
+        let mut v: Vec<T> = Vec::with_capacity(LENGTH);
+        for _ in 0..(LENGTH + 1) {
+            v.push(rand::random::<T>());
+        }
+        let packed_v = PackedVec::new(v.clone());
+        assert_eq!(packed_v.len(), v.len());
+        assert!(packed_v.iter().zip(v.iter()).all(|(x, y)| x == *y));
+    }
+
+    #[test]
+    fn random_vec() {
+        random_unsigned_ints::<u8>();
+        random_unsigned_ints::<u16>();
+        random_unsigned_ints::<u32>();
+        random_unsigned_ints::<u64>();
     }
 }


### PR DESCRIPTION
Now any kind of vector of unsigned integers can be converted to a `PackedVec`.
I'm really looking forward to some feedback on this, because I've been using `unwrap` liberally and I don't know if not handling the `None` case is necessarily good practice.
Also, the tests are getting very repetitive since they are mostly checking if `PackedVec` returns the correct `u*` back. I feel like macros could help here, but I'm not sure if it's worth making the tests less readable.